### PR TITLE
feat: wire server to on-chain contracts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Sepolia
+SEPOLIA_RPC_URL=https://sepolia.infura.io/v3/YOUR_KEY
+DEPLOYER_PRIVATE_KEY=your_private_key_here
+
+# Deployed contract addresses (after deploy)
+REEF_WORLD_ADDRESS=
+REEF_REPUTATION_ADDRESS=
+
+# 0G Testnet
+OG_RPC_URL=https://evmrpc-testnet.0g.ai
+OG_STORAGE_URL=https://storage-testnet.0g.ai
+
+# Circle Nanopayments
+CIRCLE_API_KEY=
+
+# Server
+PORT=3001
+TICK_INTERVAL=12000

--- a/server/src/chain.js
+++ b/server/src/chain.js
@@ -1,0 +1,120 @@
+/**
+ * Chain integration — connects server to on-chain contracts.
+ *
+ * Commits world state hashes each tick and records reputation on-chain.
+ * Gracefully degrades if no chain config is provided (local dev mode).
+ */
+
+import { ethers } from 'ethers';
+
+const REEF_WORLD_ABI = [
+  'function commitTick(uint256 tickNumber, bytes32 stateHash) external',
+  'function latestTick() view returns (uint256)',
+  'function verifyTick(uint256 tickNumber, bytes32 stateHash) view returns (bool)',
+  'event TickCommitted(uint256 indexed tickNumber, bytes32 stateHash, uint256 blockNumber)',
+];
+
+const REEF_REPUTATION_ABI = [
+  'function registerAgent(address agent) external',
+  'function recordTransaction(address agent) external',
+  'function rate(address agent, uint8 score) external',
+  'function getAvgRating(address agent) view returns (uint256)',
+  'function getBuildCap(address agent) view returns (uint256)',
+  'function getAgentCount() view returns (uint256)',
+  'event AgentRegistered(address indexed agent)',
+  'event RatingSubmitted(address indexed rater, address indexed agent, uint8 score)',
+];
+
+export class ChainConnector {
+  constructor() {
+    this.enabled = false;
+    this.provider = null;
+    this.signer = null;
+    this.reefWorld = null;
+    this.reefReputation = null;
+  }
+
+  async init() {
+    const rpcUrl = process.env.SEPOLIA_RPC_URL;
+    const privateKey = process.env.DEPLOYER_PRIVATE_KEY;
+    const worldAddr = process.env.REEF_WORLD_ADDRESS;
+    const repAddr = process.env.REEF_REPUTATION_ADDRESS;
+
+    if (!rpcUrl || !privateKey || !worldAddr || !repAddr) {
+      console.log('  Chain: disabled (missing env vars). Running in local-only mode.');
+      return;
+    }
+
+    try {
+      this.provider = new ethers.JsonRpcProvider(rpcUrl);
+      this.signer = new ethers.Wallet(privateKey, this.provider);
+      this.reefWorld = new ethers.Contract(worldAddr, REEF_WORLD_ABI, this.signer);
+      this.reefReputation = new ethers.Contract(repAddr, REEF_REPUTATION_ABI, this.signer);
+
+      const network = await this.provider.getNetwork();
+      const latestTick = await this.reefWorld.latestTick();
+      const agentCount = await this.reefReputation.getAgentCount();
+
+      console.log(`  Chain: connected to ${network.name} (chainId: ${network.chainId})`);
+      console.log(`  ReefWorld: ${worldAddr} (latestTick: ${latestTick})`);
+      console.log(`  ReefReputation: ${repAddr} (agents: ${agentCount})`);
+
+      this.enabled = true;
+    } catch (err) {
+      console.error(`  Chain: failed to connect — ${err.message}`);
+      console.log('  Running in local-only mode.');
+    }
+  }
+
+  /**
+   * Commit a world state hash on-chain for the given tick.
+   */
+  async commitTick(tickNumber, stateHash) {
+    if (!this.enabled) return null;
+
+    try {
+      // Convert hex string hash to bytes32
+      const hashBytes = '0x' + stateHash;
+      const tx = await this.reefWorld.commitTick(tickNumber, hashBytes);
+      const receipt = await tx.wait();
+      console.log(`  Chain: tick ${tickNumber} committed (tx: ${receipt.hash})`);
+      return receipt;
+    } catch (err) {
+      console.error(`  Chain: failed to commit tick ${tickNumber} — ${err.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Register an agent on-chain for reputation tracking.
+   */
+  async registerAgent(agentAddress) {
+    if (!this.enabled) return null;
+
+    try {
+      const tx = await this.reefReputation.registerAgent(agentAddress);
+      const receipt = await tx.wait();
+      console.log(`  Chain: agent ${agentAddress} registered (tx: ${receipt.hash})`);
+      return receipt;
+    } catch (err) {
+      console.error(`  Chain: failed to register agent — ${err.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Record a service transaction on-chain.
+   */
+  async recordTransaction(agentAddress) {
+    if (!this.enabled) return null;
+
+    try {
+      const tx = await this.reefReputation.recordTransaction(agentAddress);
+      await tx.wait();
+      return true;
+    } catch (err) {
+      console.error(`  Chain: failed to record transaction — ${err.message}`);
+      return null;
+    }
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -9,9 +9,10 @@ import express from 'express';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 import { World } from './world.js';
+import { ChainConnector } from './chain.js';
 
 const PORT = process.env.PORT || 3001;
-const TICK_INTERVAL = 12_000; // 12 seconds, matching Sepolia block time
+const TICK_INTERVAL = parseInt(process.env.TICK_INTERVAL) || 12_000;
 
 const app = express();
 app.use(express.json());
@@ -22,6 +23,7 @@ const io = new Server(httpServer, {
 });
 
 const world = new World();
+const chain = new ChainConnector();
 
 // ── REST API ─────────────────────────────────────────────────────────
 
@@ -70,13 +72,18 @@ io.on('connection', (socket) => {
   socket.emit('world:state', world.getState());
 
   // Agent registration
-  socket.on('agent:register', ({ id, name, archetype }) => {
+  socket.on('agent:register', async ({ id, name, archetype, walletAddress }) => {
     const result = world.addAgent(id, name, archetype);
     if (result.error) {
       socket.emit('agent:error', result);
     } else {
       socket.emit('agent:registered', result);
       io.emit('world:agent_joined', { agent: result.agent, tile: result.tile });
+
+      // Register on-chain if wallet address provided
+      if (walletAddress) {
+        await chain.registerAgent(walletAddress);
+      }
     }
   });
 
@@ -104,26 +111,36 @@ io.on('connection', (socket) => {
 
 // ── Tick Loop ────────────────────────────────────────────────────────
 
-setInterval(() => {
+setInterval(async () => {
   world.advanceTick();
   const state = world.getState();
   const hash = world.getStateHash();
 
   io.emit('world:tick', { tick: world.tick, hash, state });
 
+  // Commit state hash on-chain
+  await chain.commitTick(world.tick, hash);
+
   console.log(`Tick ${world.tick} | ${world.agents.size} agents | ${world.tiles.size} tiles | hash: ${hash.slice(0, 16)}...`);
 }, TICK_INTERVAL);
 
 // ── Start ────────────────────────────────────────────────────────────
 
-httpServer.listen(PORT, () => {
-  console.log(`
+async function start() {
+  await chain.init();
+
+  httpServer.listen(PORT, () => {
+    console.log(`
   ┌─────────────────────────────────────┐
-  │  🪸  The Reef — Server               │
+  │  The Reef — Server                  │
   │                                     │
   │  REST API:    http://localhost:${PORT} │
   │  WebSocket:   ws://localhost:${PORT}   │
   │  Tick interval: ${TICK_INTERVAL / 1000}s               │
+  │  Chain: ${chain.enabled ? 'connected' : 'local-only'}             │
   └─────────────────────────────────────┘
-  `);
-});
+    `);
+  });
+}
+
+start();


### PR DESCRIPTION
## Summary
- **ChainConnector** module connecting server to ReefWorld + ReefReputation on Sepolia
- Commits world state hash on-chain each tick via `commitTick`
- Registers agents on-chain for reputation tracking
- Gracefully degrades to local-only mode when env vars are missing
- `.env.example` with all required config vars

## Test plan
- [x] Server starts in local-only mode without env vars
- [ ] Deploy contracts to Sepolia and test with real RPC
- [ ] Verify tick commits appear on-chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)